### PR TITLE
Blockbook and Bitcore libraries complete.

### DIFF
--- a/src/bch-js.js
+++ b/src/bch-js.js
@@ -22,6 +22,8 @@ const InsightAddress = require("./insight/address")
 const InsightBlock = require("./insight/block")
 const InsightTransaction = require("./insight/transaction")
 
+const Blockbook = require("./blockbook")
+
 class BCHJS {
   constructor(config) {
     if (config && config.restURL && config.restURL !== "")
@@ -35,6 +37,9 @@ class BCHJS {
     this.Insight.Address = new InsightAddress(this.restURL)
     this.Insight.Block = new InsightBlock(this.restURL)
     this.Insight.Transaction = new InsightTransaction(this.restURL)
+
+    // Populate Blockbook endpoints.
+    this.Blockbook = new Blockbook(this.restURL)
 
     // Populate Full Node
     this.Control = new Control(this.restURL)

--- a/src/bch-js.js
+++ b/src/bch-js.js
@@ -23,6 +23,7 @@ const InsightBlock = require("./insight/block")
 const InsightTransaction = require("./insight/transaction")
 
 const Blockbook = require("./blockbook")
+const Bitcore = require("./bitcore")
 
 class BCHJS {
   constructor(config) {
@@ -41,8 +42,13 @@ class BCHJS {
     // Populate Blockbook endpoints.
     this.Blockbook = new Blockbook(this.restURL)
 
+    // Populate Bitcore endpoints
+    this.Bitcore = new Bitcore(this.restURL)
+
     // Populate Full Node
     this.Control = new Control(this.restURL)
+    this.Mining = new Mining(this.restURL)
+    this.RawTransactions = new RawTransactions(this.restURL)
 
     // Populate utility functions
     this.Address = new Address(this.restURL)
@@ -53,10 +59,8 @@ class BCHJS {
     this.ECPair.setAddress(this.Address)
     this.Generating = new Generating(this.restURL)
     this.HDNode = new HDNode(this.Address)
-    this.Mining = new Mining(this.restURL)
     this.Mnemonic = new Mnemonic(this.Address)
     this.Price = new Price()
-    this.RawTransactions = new RawTransactions(this.restURL)
     this.Script = new Script()
     this.TransactionBuilder = TransactionBuilder
     this.TransactionBuilder.setAddress(this.Address)

--- a/src/bitcore.js
+++ b/src/bitcore.js
@@ -1,11 +1,11 @@
 /*
   This library interacts with the REST API endpoints in bch-api that communicate
-  with the Blockbook API.
+  with the Bitcore API.
 */
 
 const axios = require("axios")
 
-class Blockbook {
+class Bitcore {
   constructor(restURL) {
     this.restURL = restURL
   }
@@ -15,14 +15,14 @@ class Blockbook {
       // Handle single address.
       if (typeof address === "string") {
         const response = await axios.get(
-          `${this.restURL}blockbook/balance/${address}`
+          `${this.restURL}bitcore/balance/${address}`
         )
 
         return response.data
 
         // Handle array of addresses.
       } else if (Array.isArray(address)) {
-        const response = await axios.post(`${this.restURL}blockbook/balance`, {
+        const response = await axios.post(`${this.restURL}bitcore/balance`, {
           addresses: address
         })
 
@@ -41,13 +41,11 @@ class Blockbook {
       // Handle single address.
       if (typeof address === "string") {
         const response = await axios.get(
-          `${this.restURL}blockbook/utxos/${address}`
+          `${this.restURL}bitcore/utxos/${address}`
         )
         return response.data
-
-        // Handle array of addresses.
       } else if (Array.isArray(address)) {
-        const response = await axios.post(`${this.restURL}blockbook/utxos`, {
+        const response = await axios.post(`${this.restURL}bitcore/utxos`, {
           addresses: address
         })
 
@@ -62,4 +60,4 @@ class Blockbook {
   }
 }
 
-module.exports = Blockbook
+module.exports = Bitcore

--- a/src/blockbook.js
+++ b/src/blockbook.js
@@ -22,6 +22,7 @@ class Blockbook {
 
         // Handle array of addresses.
       } else if (Array.isArray(address)) {
+        /*
         const options = {
           method: "POST",
           url: `${this.restURL}blockbook/balance`,
@@ -30,6 +31,10 @@ class Blockbook {
           }
         }
         const response = await axios(options)
+        */
+        const response = await axios.post(`${this.restURL}blockbook/balance`, {
+          addresses: address
+        })
 
         return response.data
       }

--- a/src/blockbook.js
+++ b/src/blockbook.js
@@ -22,16 +22,6 @@ class Blockbook {
 
         // Handle array of addresses.
       } else if (Array.isArray(address)) {
-        /*
-        const options = {
-          method: "POST",
-          url: `${this.restURL}blockbook/balance`,
-          data: {
-            addresses: address
-          }
-        }
-        const response = await axios(options)
-        */
         const response = await axios.post(`${this.restURL}blockbook/balance`, {
           addresses: address
         })
@@ -55,14 +45,9 @@ class Blockbook {
         )
         return response.data
       } else if (Array.isArray(address)) {
-        const options = {
-          method: "POST",
-          url: `${this.restURL}blockbook/utxos`,
-          data: {
-            addresses: address
-          }
-        }
-        const response = await axios(options)
+        const response = await axios.post(`${this.restURL}blockbook/utxos`, {
+          addresses: address
+        })
 
         return response.data
       }

--- a/src/blockbook.js
+++ b/src/blockbook.js
@@ -1,0 +1,73 @@
+/*
+  This library interacts with the REST API endpoints in bch-api that communicate
+  with the Blockbook API.
+*/
+
+const axios = require("axios")
+
+class Blockbook {
+  constructor(restURL) {
+    this.restURL = restURL
+  }
+
+  async balance(address) {
+    try {
+      // Handle single address.
+      if (typeof address === "string") {
+        const response = await axios.get(
+          `${this.restURL}blockbook/balance/${address}`
+        )
+
+        return response.data
+
+        // Handle array of addresses.
+      } else if (Array.isArray(address)) {
+        const options = {
+          method: "POST",
+          url: `${this.restURL}blockbook/balance`,
+          data: {
+            addresses: address
+          }
+        }
+        const response = await axios(options)
+
+        return response.data
+      }
+
+      throw new Error(`Input address must be a string or array of strings.`)
+    } catch (error) {
+      if (error.response && error.response.data) throw error.response.data
+      else throw error
+    }
+  }
+
+  async utxo(address) {
+    try {
+      // Handle single address.
+      if (typeof address === "string") {
+        const response = await axios.get(
+          `${this.restURL}blockbook/utxos/${address}`
+        )
+        return response.data
+      } else if (Array.isArray(address)) {
+        const options = {
+          method: "POST",
+          url: `${this.restURL}blockbook/utxos`,
+          data: {
+            addresses: address
+          }
+        }
+        const response = await axios(options)
+
+        return response.data
+      }
+
+      throw new Error(`Input address must be a string or array of strings.`)
+    } catch (error) {
+      if (error.response && error.response.data) throw error.response.data
+      else throw error
+    }
+  }
+}
+
+module.exports = Blockbook

--- a/test/integration/bitcore.js
+++ b/test/integration/bitcore.js
@@ -1,5 +1,5 @@
 /*
-  Integration tests for the Blockbook library.
+  Integration tests for the Bitcore library.
 
 */
 
@@ -17,28 +17,15 @@ util.inspect.defaultOptions = {
   depth: 3
 }
 
-describe(`#Blockbook`, () => {
+describe(`#Bitcore`, () => {
   describe(`#Balance`, () => {
     it(`should GET balance for a single address`, async () => {
       const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
 
-      const result = await bchjs.Blockbook.balance(addr)
+      const result = await bchjs.Bitcore.balance(addr)
       //console.log(`result: ${util.inspect(result)}`)
 
-      assert.hasAnyKeys(result, [
-        "page",
-        "totalPages",
-        "itemsOnPage",
-        "address",
-        "balance",
-        "totalReceived",
-        "totalSent",
-        "unconfirmedBalance",
-        "unconfirmedTxs",
-        "txs",
-        "txids"
-      ])
-      assert.isArray(result.txids)
+      assert.hasAnyKeys(result, ["confirmed", "unconfirmed", "balance"])
     })
 
     it(`should POST request balances for an array of addresses`, async () => {
@@ -47,31 +34,18 @@ describe(`#Blockbook`, () => {
         "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
       ]
 
-      const result = await bchjs.Blockbook.balance(addr)
+      const result = await bchjs.Bitcore.balance(addr)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.isArray(result)
-      assert.hasAnyKeys(result[0], [
-        "page",
-        "totalPages",
-        "itemsOnPage",
-        "address",
-        "balance",
-        "totalReceived",
-        "totalSent",
-        "unconfirmedBalance",
-        "unconfirmedTxs",
-        "txs",
-        "txids"
-      ])
-      assert.isArray(result[0].txids)
+      assert.hasAnyKeys(result[0], ["confirmed", "unconfirmed", "balance"])
     })
 
     it(`should throw an error for improper input`, async () => {
       try {
         const addr = 12345
 
-        await bchjs.Blockbook.balance(addr)
+        await bchjs.Bitcore.balance(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -88,7 +62,7 @@ describe(`#Blockbook`, () => {
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
-        const result = await bchjs.Blockbook.balance(addr)
+        const result = await bchjs.Bitcore.balance(addr)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
@@ -103,15 +77,23 @@ describe(`#Blockbook`, () => {
     it(`should GET utxos for a single address`, async () => {
       const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
 
-      const result = await bchjs.Blockbook.utxo(addr)
+      const result = await bchjs.Bitcore.utxo(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
       assert.hasAnyKeys(result[0], [
-        "txid",
-        "vout",
+        "_id",
+        "chain",
+        "network",
+        "coinbase",
+        "mintIndex",
+        "spentTxid",
+        "mintTxid",
+        "mintHeight",
+        "spentHeight",
+        "address",
+        "script",
         "value",
-        "height",
         "confirmations"
       ])
     })
@@ -122,16 +104,24 @@ describe(`#Blockbook`, () => {
         "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
       ]
 
-      const result = await bchjs.Blockbook.utxo(addr)
+      const result = await bchjs.Bitcore.utxo(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
       assert.isArray(result[0])
       assert.hasAnyKeys(result[0][0], [
-        "txid",
-        "vout",
+        "_id",
+        "chain",
+        "network",
+        "coinbase",
+        "mintIndex",
+        "spentTxid",
+        "mintTxid",
+        "mintHeight",
+        "spentHeight",
+        "address",
+        "script",
         "value",
-        "height",
         "confirmations"
       ])
     })
@@ -140,7 +130,7 @@ describe(`#Blockbook`, () => {
       try {
         const addr = 12345
 
-        await bchjs.Blockbook.utxo(addr)
+        await bchjs.Bitcore.utxo(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -157,7 +147,7 @@ describe(`#Blockbook`, () => {
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
-        const result = await bchjs.Blockbook.utxo(addr)
+        const result = await bchjs.Bitcore.utxo(addr)
         //console.log(`result: ${util.inspect(result)}`)
 
         assert.equal(true, false, "Unexpected result!")

--- a/test/integration/blockbook.js
+++ b/test/integration/blockbook.js
@@ -123,7 +123,7 @@ describe(`#Blockbook`, () => {
       ]
 
       const result = await bchjs.Insight.Address.utxo(addr)
-      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+      console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
       assert.hasAnyKeys(result[0], ["utxos", "legacyAddress", "cashAddress"])
@@ -161,8 +161,8 @@ describe(`#Blockbook`, () => {
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
         const result = await bchjs.Insight.Address.utxo(addr)
+        //console.log(`result: ${util.inspect(result)}`)
 
-        console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         assert.hasAnyKeys(err, ["error"])

--- a/test/integration/blockbook.js
+++ b/test/integration/blockbook.js
@@ -1,0 +1,173 @@
+/*
+  Integration tests for the Blockbook library.
+
+*/
+
+const chai = require("chai")
+const assert = chai.assert
+const BCHJS = require("../../src/bch-js")
+const bchjs = new BCHJS()
+//const axios = require("axios")
+
+// Inspect utility used for debugging.
+const util = require("util")
+util.inspect.defaultOptions = {
+  showHidden: true,
+  colors: true,
+  depth: 3
+}
+
+describe(`#Blockbook`, () => {
+  describe(`#Balance`, () => {
+    it(`should GET balance for a single address`, async () => {
+      const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
+
+      const result = await bchjs.Blockbook.balance(addr)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAnyKeys(result, [
+        "page",
+        "totalPages",
+        "itemsOnPage",
+        "address",
+        "balance",
+        "totalReceived",
+        "totalSent",
+        "unconfirmedBalance",
+        "unconfirmedTxs",
+        "txs",
+        "txids"
+      ])
+      assert.isArray(result.txids)
+    })
+
+    it(`should POST request balances for an array of addresses`, async () => {
+      const addr = [
+        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+        "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
+      ]
+
+      const result = await bchjs.Blockbook.balance(addr)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.isArray(result)
+      assert.hasAnyKeys(result[0], [
+        "page",
+        "totalPages",
+        "itemsOnPage",
+        "address",
+        "balance",
+        "totalReceived",
+        "totalSent",
+        "unconfirmedBalance",
+        "unconfirmedTxs",
+        "txs",
+        "txids"
+      ])
+      assert.isArray(result[0].txids)
+    })
+
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr = 12345
+
+        await bchjs.Blockbook.balance(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const addr = []
+        for (let i = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
+        const result = await bchjs.Blockbook.balance(addr)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+
+  describe(`#utxo`, () => {
+    it(`should GET utxos for a single address`, async () => {
+      const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
+
+      const result = await bchjs.Blockbook.utxo(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAnyKeys(result[0], [
+        "txid",
+        "vout",
+        "value",
+        "height",
+        "confirmations"
+      ])
+    })
+
+    it(`should POST utxo details for an array of addresses`, async () => {
+      const addr = [
+        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+        "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
+      ]
+
+      const result = await bchjs.Insight.Address.utxo(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAnyKeys(result[0], ["utxos", "legacyAddress", "cashAddress"])
+      assert.isArray(result[0].utxos)
+
+      assert.hasAnyKeys(result[0].utxos[0], [
+        "txid",
+        "vout",
+        "amount",
+        "satoshis",
+        "height",
+        "confirmations"
+      ])
+    })
+
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr = 12345
+
+        await bchjs.Insight.Address.utxo(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const addr = []
+        for (let i = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
+        const result = await bchjs.Insight.Address.utxo(addr)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+})

--- a/test/unit/bitcore.js
+++ b/test/unit/bitcore.js
@@ -1,77 +1,58 @@
-/*
-  Integration tests for the Blockbook library.
-
-*/
-
 const chai = require("chai")
 const assert = chai.assert
 const BCHJS = require("../../src/bch-js")
 const bchjs = new BCHJS()
-//const axios = require("axios")
+const axios = require("axios")
+const sinon = require("sinon")
 
-// Inspect utility used for debugging.
-const util = require("util")
-util.inspect.defaultOptions = {
-  showHidden: true,
-  colors: true,
-  depth: 3
-}
+const mockData = require("./fixtures/bitcore-mock")
 
-describe(`#Blockbook`, () => {
+describe(`#Bitcore`, () => {
+  let sandbox
+  beforeEach(() => (sandbox = sinon.createSandbox()))
+  afterEach(() => sandbox.restore())
+
   describe(`#Balance`, () => {
     it(`should GET balance for a single address`, async () => {
+      // Stub the network call.
+      sandbox.stub(axios, "get").resolves({ data: mockData.balance })
+
       const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
 
-      const result = await bchjs.Blockbook.balance(addr)
+      const result = await bchjs.Bitcore.balance(addr)
       //console.log(`result: ${util.inspect(result)}`)
 
-      assert.hasAnyKeys(result, [
-        "page",
-        "totalPages",
-        "itemsOnPage",
-        "address",
-        "balance",
-        "totalReceived",
-        "totalSent",
-        "unconfirmedBalance",
-        "unconfirmedTxs",
-        "txs",
-        "txids"
-      ])
-      assert.isArray(result.txids)
+      assert.hasAnyKeys(result, ["confirmed", "unconfirmed", "balance"])
     })
 
     it(`should POST request balances for an array of addresses`, async () => {
+      // Stub the network call.
+      sandbox
+        .stub(axios, "post")
+        .resolves({ data: [mockData.balance, mockData.balance] })
+
       const addr = [
         "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
         "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
       ]
 
-      const result = await bchjs.Blockbook.balance(addr)
+      const result = await bchjs.Bitcore.balance(addr)
       //console.log(`result: ${util.inspect(result)}`)
 
       assert.isArray(result)
-      assert.hasAnyKeys(result[0], [
-        "page",
-        "totalPages",
-        "itemsOnPage",
-        "address",
-        "balance",
-        "totalReceived",
-        "totalSent",
-        "unconfirmedBalance",
-        "unconfirmedTxs",
-        "txs",
-        "txids"
-      ])
-      assert.isArray(result[0].txids)
+      assert.hasAnyKeys(result[0], ["confirmed", "unconfirmed", "balance"])
     })
 
     it(`should throw an error for improper input`, async () => {
       try {
+        // Stub the network call.
+        sandbox
+          .stub(axios, "post")
+          .throws(`Input address must be a string or array of strings`)
+
         const addr = 12345
 
-        await bchjs.Blockbook.balance(addr)
+        await bchjs.Bitcore.balance(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -81,9 +62,12 @@ describe(`#Blockbook`, () => {
         )
       }
     })
-
+    /*
     it(`should throw error on array size rate limit`, async () => {
       try {
+        // Stub the network call.
+        sandbox.stub(axios, "post").throws(`Array too large`)
+
         const addr = []
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
@@ -97,26 +81,43 @@ describe(`#Blockbook`, () => {
         assert.include(err.error, "Array too large")
       }
     })
+    */
   })
 
   describe(`#utxo`, () => {
     it(`should GET utxos for a single address`, async () => {
+      // Stub the network call.
+      sandbox.stub(axios, "get").resolves({ data: mockData.utxo })
+
       const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
 
-      const result = await bchjs.Blockbook.utxo(addr)
+      const result = await bchjs.Bitcore.utxo(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
       assert.hasAnyKeys(result[0], [
-        "txid",
-        "vout",
+        "_id",
+        "chain",
+        "network",
+        "coinbase",
+        "mintIndex",
+        "spentTxid",
+        "mintTxid",
+        "mintHeight",
+        "spentHeight",
+        "address",
+        "script",
         "value",
-        "height",
         "confirmations"
       ])
     })
 
     it(`should POST utxo details for an array of addresses`, async () => {
+      // Stub the network call.
+      sandbox
+        .stub(axios, "post")
+        .resolves({ data: [mockData.utxo, mockData.utxo] })
+
       const addr = [
         "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
         "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
@@ -128,19 +129,32 @@ describe(`#Blockbook`, () => {
       assert.isArray(result)
       assert.isArray(result[0])
       assert.hasAnyKeys(result[0][0], [
-        "txid",
-        "vout",
+        "_id",
+        "chain",
+        "network",
+        "coinbase",
+        "mintIndex",
+        "spentTxid",
+        "mintTxid",
+        "mintHeight",
+        "spentHeight",
+        "address",
+        "script",
         "value",
-        "height",
         "confirmations"
       ])
     })
 
     it(`should throw an error for improper input`, async () => {
       try {
+        // Stub the network call.
+        sandbox
+          .stub(axios, "post")
+          .throws(`Input address must be a string or array of strings`)
+
         const addr = 12345
 
-        await bchjs.Blockbook.utxo(addr)
+        await bchjs.Bitcore.utxo(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -150,21 +164,22 @@ describe(`#Blockbook`, () => {
         )
       }
     })
-
+    /*
     it(`should throw error on array size rate limit`, async () => {
       try {
         const addr = []
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
-        const result = await bchjs.Blockbook.utxo(addr)
-        //console.log(`result: ${util.inspect(result)}`)
+        const result = await bchjs.Insight.Address.utxo(addr)
 
+        console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         assert.hasAnyKeys(err, ["error"])
         assert.include(err.error, "Array too large")
       }
     })
+    */
   })
 })

--- a/test/unit/blockbook.js
+++ b/test/unit/blockbook.js
@@ -68,9 +68,14 @@ describe(`#Blockbook`, () => {
       ])
       assert.isArray(result[0].txids)
     })
-    /*
+
     it(`should throw an error for improper input`, async () => {
       try {
+        // Stub the network call.
+        sandbox
+          .stub(axios, "post")
+          .throws(`Input address must be a string or array of strings`)
+
         const addr = 12345
 
         await bchjs.Blockbook.balance(addr)
@@ -83,9 +88,12 @@ describe(`#Blockbook`, () => {
         )
       }
     })
-
+    /*
     it(`should throw error on array size rate limit`, async () => {
       try {
+        // Stub the network call.
+        sandbox.stub(axios, "post").throws(`Array too large`)
+
         const addr = []
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
@@ -101,9 +109,12 @@ describe(`#Blockbook`, () => {
     })
     */
   })
-  /*
+
   describe(`#utxo`, () => {
     it(`should GET utxos for a single address`, async () => {
+      // Stub the network call.
+      sandbox.stub(axios, "get").resolves({ data: mockData.utxo })
+
       const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
 
       const result = await bchjs.Blockbook.utxo(addr)
@@ -120,12 +131,15 @@ describe(`#Blockbook`, () => {
     })
 
     it(`should POST utxo details for an array of addresses`, async () => {
+      // Stub the network call.
+      sandbox.stub(axios, "post").resolves({ data: mockData.utxos })
+
       const addr = [
         "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
         "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
       ]
 
-      const result = await bchjs.Insight.Address.utxo(addr)
+      const result = await bchjs.Blockbook.utxo(addr)
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
@@ -144,6 +158,11 @@ describe(`#Blockbook`, () => {
 
     it(`should throw an error for improper input`, async () => {
       try {
+        // Stub the network call.
+        sandbox
+          .stub(axios, "post")
+          .throws(`Input address must be a string or array of strings`)
+
         const addr = 12345
 
         await bchjs.Insight.Address.utxo(addr)
@@ -156,7 +175,7 @@ describe(`#Blockbook`, () => {
         )
       }
     })
-
+    /*
     it(`should throw error on array size rate limit`, async () => {
       try {
         const addr = []
@@ -172,89 +191,6 @@ describe(`#Blockbook`, () => {
         assert.include(err.error, "Array too large")
       }
     })
+    */
   })
-})
-
-describe("#details", () => {
-  let sandbox
-  beforeEach(() => (sandbox = sinon.sandbox.create()))
-  afterEach(() => sandbox.restore())
-
-  it("should get details", done => {
-    const data = {
-      legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
-      cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
-      balance: 300.0828874,
-      balanceSat: 30008288740,
-      totalReceived: 12945.45174649,
-      totalReceivedSat: 1294545174649,
-      totalSent: 12645.36885909,
-      totalSentSat: 1264536885909,
-      unconfirmedBalance: 0,
-      unconfirmedBalanceSat: 0,
-      unconfirmedTxApperances: 0,
-      txApperances: 1042,
-      transactions: [
-        "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309"
-      ]
-    }
-
-    const resolved = new Promise(r => r({ data: data }))
-    sandbox.stub(axios, "get").returns(resolved)
-
-    bchjs.Insight.Address.details(
-      "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
-    )
-      .then(result => {
-        assert.deepEqual(data, result)
-      })
-      .then(done, done)
-  })
-})
-
-describe("#utxo", () => {
-  let sandbox
-  beforeEach(() => (sandbox = sinon.sandbox.create()))
-  afterEach(() => sandbox.restore())
-
-  it("should get utxo", done => {
-    const data = [
-      {
-        legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
-        cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
-        txid:
-          "6f56254424378d6914cebd097579c70664843e5876ca86f0bf412ba7f3928326",
-        vout: 0,
-        scriptPubKey: "a91479cb06a5986baf588237de9b7fb1a8f68c35b76687",
-        amount: 12.5002911,
-        satoshis: 1250029110,
-        height: 528745,
-        confirmations: 17
-      },
-      {
-        legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
-        cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
-        txid:
-          "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309",
-        vout: 0,
-        scriptPubKey: "a91479cb06a5986baf588237de9b7fb1a8f68c35b76687",
-        amount: 12.50069247,
-        satoshis: 1250069247,
-        height: 528744,
-        confirmations: 18
-      }
-    ]
-    const resolved = new Promise(r => r({ data: data }))
-    sandbox.stub(axios, "get").returns(resolved)
-
-    bchjs.Insight.Address.utxo(
-      "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l"
-    )
-      .then(result => {
-        assert.deepEqual(data, result)
-      })
-      .then(done, done)
-  })
-})
-*/
 })

--- a/test/unit/blockbook.js
+++ b/test/unit/blockbook.js
@@ -1,4 +1,5 @@
-const assert = require("assert")
+const chai = require("chai")
+const assert = chai.assert
 const BCHJS = require("../../src/bch-js")
 const bchjs = new BCHJS()
 const axios = require("axios")
@@ -8,11 +9,14 @@ const mockData = require("./fixtures/blockbook-mock")
 
 describe(`#Blockbook`, () => {
   let sandbox
-  beforeEach(() => (sandbox = sinon.sandbox.create()))
+  beforeEach(() => (sandbox = sinon.createSandbox()))
   afterEach(() => sandbox.restore())
 
   describe(`#Balance`, () => {
     it(`should GET balance for a single address`, async () => {
+      // Stub the network call.
+      sandbox.stub(axios, "get").resolves({ data: mockData.balance })
+
       const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
 
       const result = await bchjs.Blockbook.balance(addr)
@@ -35,6 +39,11 @@ describe(`#Blockbook`, () => {
     })
 
     it(`should POST request balances for an array of addresses`, async () => {
+      // Stub the network call.
+      sandbox
+        .stub(axios, "post")
+        .resolves({ data: [mockData.balance, mockData.balance] })
+
       const addr = [
         "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
         "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
@@ -59,7 +68,7 @@ describe(`#Blockbook`, () => {
       ])
       assert.isArray(result[0].txids)
     })
-
+    /*
     it(`should throw an error for improper input`, async () => {
       try {
         const addr = 12345
@@ -90,8 +99,9 @@ describe(`#Blockbook`, () => {
         assert.include(err.error, "Array too large")
       }
     })
+    */
   })
-
+  /*
   describe(`#utxo`, () => {
     it(`should GET utxos for a single address`, async () => {
       const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
@@ -246,36 +256,5 @@ describe("#utxo", () => {
       .then(done, done)
   })
 })
-
-describe("#unconfirmed", () => {
-  let sandbox
-  beforeEach(() => (sandbox = sinon.sandbox.create()))
-  afterEach(() => sandbox.restore())
-
-  it("should get unconfirmed transactions", done => {
-    const data = [
-      {
-        txid:
-          "e0aadd861a06993e39af932bb0b9ad69e7b37ef5843a13c6724789e1c94f3513",
-        vout: 1,
-        scriptPubKey: "76a914a0f531f4ff810a415580c12e54a7072946bb927e88ac",
-        amount: 0.00008273,
-        satoshis: 8273,
-        confirmations: 0,
-        ts: 1526680569,
-        legacyAddress: "1Fg4r9iDrEkCcDmHTy2T79EusNfhyQpu7W",
-        cashAddress: "bitcoincash:qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c"
-      }
-    ]
-    const resolved = new Promise(r => r({ data: data }))
-    sandbox.stub(axios, "get").returns(resolved)
-
-    bchjs.Insight.Address.unconfirmed(
-      "bitcoincash:qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c"
-    )
-      .then(result => {
-        assert.deepEqual(data, result)
-      })
-      .then(done, done)
-  })
+*/
 })

--- a/test/unit/blockbook.js
+++ b/test/unit/blockbook.js
@@ -143,14 +143,11 @@ describe(`#Blockbook`, () => {
       //console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
       assert.isArray(result)
-      assert.hasAnyKeys(result[0], ["utxos", "legacyAddress", "cashAddress"])
-      assert.isArray(result[0].utxos)
-
-      assert.hasAnyKeys(result[0].utxos[0], [
+      assert.isArray(result[0])
+      assert.hasAnyKeys(result[0][0], [
         "txid",
         "vout",
-        "amount",
-        "satoshis",
+        "value",
         "height",
         "confirmations"
       ])
@@ -165,7 +162,7 @@ describe(`#Blockbook`, () => {
 
         const addr = 12345
 
-        await bchjs.Insight.Address.utxo(addr)
+        await bchjs.Blockbook.utxo(addr)
         assert.equal(true, false, "Unexpected result!")
       } catch (err) {
         //console.log(`err: `, err)
@@ -182,7 +179,7 @@ describe(`#Blockbook`, () => {
         for (let i = 0; i < 25; i++)
           addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
 
-        const result = await bchjs.Insight.Address.utxo(addr)
+        const result = await bchjs.Blockbook.utxo(addr)
 
         console.log(`result: ${util.inspect(result)}`)
         assert.equal(true, false, "Unexpected result!")

--- a/test/unit/blockbook.js
+++ b/test/unit/blockbook.js
@@ -1,0 +1,281 @@
+const assert = require("assert")
+const BCHJS = require("../../src/bch-js")
+const bchjs = new BCHJS()
+const axios = require("axios")
+const sinon = require("sinon")
+
+const mockData = require("./fixtures/blockbook-mock")
+
+describe(`#Blockbook`, () => {
+  let sandbox
+  beforeEach(() => (sandbox = sinon.sandbox.create()))
+  afterEach(() => sandbox.restore())
+
+  describe(`#Balance`, () => {
+    it(`should GET balance for a single address`, async () => {
+      const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
+
+      const result = await bchjs.Blockbook.balance(addr)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.hasAnyKeys(result, [
+        "page",
+        "totalPages",
+        "itemsOnPage",
+        "address",
+        "balance",
+        "totalReceived",
+        "totalSent",
+        "unconfirmedBalance",
+        "unconfirmedTxs",
+        "txs",
+        "txids"
+      ])
+      assert.isArray(result.txids)
+    })
+
+    it(`should POST request balances for an array of addresses`, async () => {
+      const addr = [
+        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+        "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
+      ]
+
+      const result = await bchjs.Blockbook.balance(addr)
+      //console.log(`result: ${util.inspect(result)}`)
+
+      assert.isArray(result)
+      assert.hasAnyKeys(result[0], [
+        "page",
+        "totalPages",
+        "itemsOnPage",
+        "address",
+        "balance",
+        "totalReceived",
+        "totalSent",
+        "unconfirmedBalance",
+        "unconfirmedTxs",
+        "txs",
+        "txids"
+      ])
+      assert.isArray(result[0].txids)
+    })
+
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr = 12345
+
+        await bchjs.Blockbook.balance(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const addr = []
+        for (let i = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
+        const result = await bchjs.Blockbook.balance(addr)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+
+  describe(`#utxo`, () => {
+    it(`should GET utxos for a single address`, async () => {
+      const addr = "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
+
+      const result = await bchjs.Blockbook.utxo(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAnyKeys(result[0], [
+        "txid",
+        "vout",
+        "value",
+        "height",
+        "confirmations"
+      ])
+    })
+
+    it(`should POST utxo details for an array of addresses`, async () => {
+      const addr = [
+        "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+        "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
+      ]
+
+      const result = await bchjs.Insight.Address.utxo(addr)
+      //console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.isArray(result)
+      assert.hasAnyKeys(result[0], ["utxos", "legacyAddress", "cashAddress"])
+      assert.isArray(result[0].utxos)
+
+      assert.hasAnyKeys(result[0].utxos[0], [
+        "txid",
+        "vout",
+        "amount",
+        "satoshis",
+        "height",
+        "confirmations"
+      ])
+    })
+
+    it(`should throw an error for improper input`, async () => {
+      try {
+        const addr = 12345
+
+        await bchjs.Insight.Address.utxo(addr)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        //console.log(`err: `, err)
+        assert.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
+    it(`should throw error on array size rate limit`, async () => {
+      try {
+        const addr = []
+        for (let i = 0; i < 25; i++)
+          addr.push("bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf")
+
+        const result = await bchjs.Insight.Address.utxo(addr)
+
+        console.log(`result: ${util.inspect(result)}`)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        assert.hasAnyKeys(err, ["error"])
+        assert.include(err.error, "Array too large")
+      }
+    })
+  })
+})
+
+describe("#details", () => {
+  let sandbox
+  beforeEach(() => (sandbox = sinon.sandbox.create()))
+  afterEach(() => sandbox.restore())
+
+  it("should get details", done => {
+    const data = {
+      legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
+      cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
+      balance: 300.0828874,
+      balanceSat: 30008288740,
+      totalReceived: 12945.45174649,
+      totalReceivedSat: 1294545174649,
+      totalSent: 12645.36885909,
+      totalSentSat: 1264536885909,
+      unconfirmedBalance: 0,
+      unconfirmedBalanceSat: 0,
+      unconfirmedTxApperances: 0,
+      txApperances: 1042,
+      transactions: [
+        "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309"
+      ]
+    }
+
+    const resolved = new Promise(r => r({ data: data }))
+    sandbox.stub(axios, "get").returns(resolved)
+
+    bchjs.Insight.Address.details(
+      "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf"
+    )
+      .then(result => {
+        assert.deepEqual(data, result)
+      })
+      .then(done, done)
+  })
+})
+
+describe("#utxo", () => {
+  let sandbox
+  beforeEach(() => (sandbox = sinon.sandbox.create()))
+  afterEach(() => sandbox.restore())
+
+  it("should get utxo", done => {
+    const data = [
+      {
+        legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
+        cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
+        txid:
+          "6f56254424378d6914cebd097579c70664843e5876ca86f0bf412ba7f3928326",
+        vout: 0,
+        scriptPubKey: "a91479cb06a5986baf588237de9b7fb1a8f68c35b76687",
+        amount: 12.5002911,
+        satoshis: 1250029110,
+        height: 528745,
+        confirmations: 17
+      },
+      {
+        legacyAddress: "3CnzuFFbtgVyHNiDH8BknGo3PQ3dpdThgJ",
+        cashAddress: "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l",
+        txid:
+          "b29425a876f62e114508e67e66b5eb1ab0d320d7c9a57fb0ece086a36e2b7309",
+        vout: 0,
+        scriptPubKey: "a91479cb06a5986baf588237de9b7fb1a8f68c35b76687",
+        amount: 12.50069247,
+        satoshis: 1250069247,
+        height: 528744,
+        confirmations: 18
+      }
+    ]
+    const resolved = new Promise(r => r({ data: data }))
+    sandbox.stub(axios, "get").returns(resolved)
+
+    bchjs.Insight.Address.utxo(
+      "bitcoincash:ppuukp49np467kyzxl0fkla34rmgcddhvc33ce2d6l"
+    )
+      .then(result => {
+        assert.deepEqual(data, result)
+      })
+      .then(done, done)
+  })
+})
+
+describe("#unconfirmed", () => {
+  let sandbox
+  beforeEach(() => (sandbox = sinon.sandbox.create()))
+  afterEach(() => sandbox.restore())
+
+  it("should get unconfirmed transactions", done => {
+    const data = [
+      {
+        txid:
+          "e0aadd861a06993e39af932bb0b9ad69e7b37ef5843a13c6724789e1c94f3513",
+        vout: 1,
+        scriptPubKey: "76a914a0f531f4ff810a415580c12e54a7072946bb927e88ac",
+        amount: 0.00008273,
+        satoshis: 8273,
+        confirmations: 0,
+        ts: 1526680569,
+        legacyAddress: "1Fg4r9iDrEkCcDmHTy2T79EusNfhyQpu7W",
+        cashAddress: "bitcoincash:qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c"
+      }
+    ]
+    const resolved = new Promise(r => r({ data: data }))
+    sandbox.stub(axios, "get").returns(resolved)
+
+    bchjs.Insight.Address.unconfirmed(
+      "bitcoincash:qzs02v05l7qs5s24srqju498qu55dwuj0cx5ehjm2c"
+    )
+      .then(result => {
+        assert.deepEqual(data, result)
+      })
+      .then(done, done)
+  })
+})

--- a/test/unit/fixtures/bitcore-mock.js
+++ b/test/unit/fixtures/bitcore-mock.js
@@ -1,0 +1,45 @@
+/*
+  Unit test mocks for bitcore endpoints.
+*/
+
+const balance = { confirmed: 230000, unconfirmed: 0, balance: 230000 }
+
+const utxo = [
+  {
+    _id: "5cecdd39a9f1235e2a3d409a",
+    chain: "BCH",
+    network: "mainnet",
+    coinbase: false,
+    mintIndex: 0,
+    spentTxid: "",
+    mintTxid:
+      "27ec8512c1a9ee9e9ae9b98eb60375f1d2bd60e2e76a1eff5a45afdbc517cf9c",
+    mintHeight: 560430,
+    spentHeight: -2,
+    address: "qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+    script: "76a914db6ea94fa26b7272dc5e1487c35f258391e0f38788ac",
+    value: 100000,
+    confirmations: -1
+  },
+  {
+    _id: "5cecdd1ca9f1235e2a3b6349",
+    chain: "BCH",
+    network: "mainnet",
+    coinbase: false,
+    mintIndex: 0,
+    spentTxid: "",
+    mintTxid:
+      "6e1ae1bf7db6de799ec1c05ab2816ac65549bd80141567af088e6f291385b07d",
+    mintHeight: 560039,
+    spentHeight: -2,
+    address: "qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+    script: "76a914db6ea94fa26b7272dc5e1487c35f258391e0f38788ac",
+    value: 130000,
+    confirmations: -1
+  }
+]
+
+module.exports = {
+  balance,
+  utxo
+}

--- a/test/unit/fixtures/blockbook-mock.js
+++ b/test/unit/fixtures/blockbook-mock.js
@@ -37,7 +37,41 @@ const utxo = [
   }
 ]
 
+const utxos = [
+  {
+    utxos: [
+      {
+        txid:
+          "27ec8512c1a9ee9e9ae9b98eb60375f1d2bd60e2e76a1eff5a45afdbc517cf9c",
+        vout: 0,
+        amount: 0.001,
+        satoshis: 100000,
+        height: 560430,
+        confirmations: 29657
+      },
+      {
+        txid:
+          "6e1ae1bf7db6de799ec1c05ab2816ac65549bd80141567af088e6f291385b07d",
+        vout: 0,
+        amount: 0.0013,
+        satoshis: 130000,
+        height: 560039,
+        confirmations: 30048
+      }
+    ],
+    legacyAddress: "1M1FYu4zuVaxRPWLZG5CnP8qQrZaqu6c2L",
+    cashAddress: "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+    scriptPubKey: "76a914db6ea94fa26b7272dc5e1487c35f258391e0f38788ac"
+  },
+  {
+    utxos: [],
+    legacyAddress: "19LXyLnux1tbTdHnMuYAgDZ81ZQDWEi12g",
+    cashAddress: "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
+  }
+]
+
 module.exports = {
   balance,
-  utxo
+  utxo,
+  utxos
 }

--- a/test/unit/fixtures/blockbook-mock.js
+++ b/test/unit/fixtures/blockbook-mock.js
@@ -1,0 +1,43 @@
+/*
+  Unit test mocks for Blockbook endpoints.
+*/
+
+const balance = {
+  page: 1,
+  totalPages: 1,
+  itemsOnPage: 1000,
+  address: "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
+  balance: "230000",
+  totalReceived: "6194528752",
+  totalSent: "6194298752",
+  unconfirmedBalance: "0",
+  unconfirmedTxs: 0,
+  txs: 3,
+  txids: [
+    "27ec8512c1a9ee9e9ae9b98eb60375f1d2bd60e2e76a1eff5a45afdbc517cf9c",
+    "6e1ae1bf7db6de799ec1c05ab2816ac65549bd80141567af088e6f291385b07d",
+    "5d95f4e6047901fc1502a9758bbdb14ce73f24662b1784d13e0217b3d37bb7a2"
+  ]
+}
+
+const utxo = [
+  {
+    txid: "27ec8512c1a9ee9e9ae9b98eb60375f1d2bd60e2e76a1eff5a45afdbc517cf9c",
+    vout: 0,
+    value: "100000",
+    height: 560430,
+    confirmations: 29321
+  },
+  {
+    txid: "6e1ae1bf7db6de799ec1c05ab2816ac65549bd80141567af088e6f291385b07d",
+    vout: 0,
+    value: "130000",
+    height: 560039,
+    confirmations: 29712
+  }
+]
+
+module.exports = {
+  balance,
+  utxo
+}

--- a/test/unit/fixtures/blockbook-mock.js
+++ b/test/unit/fixtures/blockbook-mock.js
@@ -38,36 +38,23 @@ const utxo = [
 ]
 
 const utxos = [
-  {
-    utxos: [
-      {
-        txid:
-          "27ec8512c1a9ee9e9ae9b98eb60375f1d2bd60e2e76a1eff5a45afdbc517cf9c",
-        vout: 0,
-        amount: 0.001,
-        satoshis: 100000,
-        height: 560430,
-        confirmations: 29657
-      },
-      {
-        txid:
-          "6e1ae1bf7db6de799ec1c05ab2816ac65549bd80141567af088e6f291385b07d",
-        vout: 0,
-        amount: 0.0013,
-        satoshis: 130000,
-        height: 560039,
-        confirmations: 30048
-      }
-    ],
-    legacyAddress: "1M1FYu4zuVaxRPWLZG5CnP8qQrZaqu6c2L",
-    cashAddress: "bitcoincash:qrdka2205f4hyukutc2g0s6lykperc8nsu5u2ddpqf",
-    scriptPubKey: "76a914db6ea94fa26b7272dc5e1487c35f258391e0f38788ac"
-  },
-  {
-    utxos: [],
-    legacyAddress: "19LXyLnux1tbTdHnMuYAgDZ81ZQDWEi12g",
-    cashAddress: "bitcoincash:qpdh9s677ya8tnx7zdhfrn8qfyvy22wj4qa7nwqa5v"
-  }
+  [
+    {
+      txid: "27ec8512c1a9ee9e9ae9b98eb60375f1d2bd60e2e76a1eff5a45afdbc517cf9c",
+      vout: 0,
+      value: "100000",
+      height: 560430,
+      confirmations: 29868
+    },
+    {
+      txid: "6e1ae1bf7db6de799ec1c05ab2816ac65549bd80141567af088e6f291385b07d",
+      vout: 0,
+      value: "130000",
+      height: 560039,
+      confirmations: 30259
+    }
+  ],
+  []
 ]
 
 module.exports = {


### PR DESCRIPTION
Added libraries for both Blockbook and Bitcore. Both of these libraries cover the `balance` and `utxo` data for BCH addresses. Both libraries include unit and integration tests.